### PR TITLE
Cron not running in docker, added to supervisord config

### DIFF
--- a/deploy/supervisord.conf
+++ b/deploy/supervisord.conf
@@ -35,3 +35,12 @@ stdout_logfile=/var/log/activemq.scot.log
 command=/usr/bin/plackup /opt/sandia/webapps/scot3/script/Scot -s Starman --listen 127.0.0.1:5100 --user scot --max-requests 1 --workers 20 --pid /opt/sandia/webapps/scot3/scot.pid
 autostart=true
 autorestart=true
+
+[program:cron]
+command=/usr/sbin/cron
+autostart=true
+autorestart=true
+user=root
+stdout_logfile=/var/log/cron.stdout.log
+stderr_logfile=/var/log/cron.stderr.log
+


### PR DESCRIPTION
Without this change, alertbot.pl never runs. Cron does work once it is added to the supervisor configuration, but I do get this error in cron.stderr.log: "/usr/sbin/cron: can't lock /var/run/crond.pid, otherpid may be 20: Resource temporarily unavailable" I'm not sure if it is a docker issue, or something with the cron configuration. It doesn't seem to impact anything.
