### PR TITLE
Update logrotate script to copy and truncate 

### DIFF
--- a/etc/logrotate.scot
+++ b/etc/logrotate.scot
@@ -4,6 +4,7 @@
     rotate 5
     compress
     notifempty
+    copytruncate
 }
 /var/log/error.*.log {
     daily

--- a/lib/Scot/Bot/Parser.pm
+++ b/lib/Scot/Bot/Parser.pm
@@ -97,7 +97,7 @@ sub log_creation {
     $log->debug("Subject is : ".$subject);
 }
 
-sub  trim { my $s = shift; $s =~ s/^\s+|\s+$//g; return $s };
+sub  trim { my $s = shift; return unless $s; $s =~ s/^\s+|\s+$//g; return $s };
 
 sub create_alerts {
     my $self        = shift;
@@ -122,7 +122,7 @@ sub create_alerts {
         plain   => $msg_href->{body_plain},
     };
 
-    my $trimmed_html = trim($body->{'html'});
+    my $trimmed_html = (defined($body->{'html'})) ? trim($body->{'html'}) : '';
     if(!defined($body->{html}) || $trimmed_html eq '') {
         my $t2h = HTML::FromText->new ({
             paras => 1,   


### PR DESCRIPTION
This change allows the perl starman processes to continue to write logs when running on docker. Since the processes run as scot and not root, they can't recreate the log file after it is rotated.